### PR TITLE
Add error checking for radio button entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,17 +160,37 @@ function myAccordion(id) {
     }
 }
 
+//**************************************************************Functions start***********************************
 function myFunction() {
 
 	var rb1 = document.getElementById("ovid");
 	var rb2 = document.getElementById("pubmed");
 	var mfInputline = document.getElementById("userEntry").value;
+	var warnOTP = "Are you sure that you meant Ovid to PubMed? I see PubMed syntax in your entry.";
+  	var warnPTO = "Are you sure that you meant PubMed to Ovid? I see Ovid syntax in your entry";
+  	warnOTP = warnOTP.fontcolor("red");
+  	warnPTO = warnPTO.fontcolor("red");
 
 
     if (rb1.checked && rb2.checked == false){
+	if (mfInputline.search(/\[/i) >= 0 && mfInputline.search(/\]/i) >= 0){
+          document.getElementById("output5").innerHTML = warnOTP;
+        }
+        else{
+          document.getElementById("output5").innerHTML = "";
+        }
     	transposeOTP(mfInputline);
     }
     else if (rb1.checked == false && rb2.checked){
+	if (mfInputline.search(/exp/i) >= 0 && mfInputline.search(/\/ /i) >= 0){
+          document.getElementById("output5").innerHTML = warnPTO;
+        }
+        else if (mfInputline.search(/.\w\w./) >= 0){
+          document.getElementById("output5").innerHTML = warnPTO;
+        }
+        else{
+          document.getElementById("output5").innerHTML = "";
+        }
       	transposePTO(mfInputline);
     }
 	else{


### PR DESCRIPTION
This code checks the user's strategy to see if it has syntax corresponding to the other radio button's value, and provides a warning if that is the case. It does not override the radio button value in case the user wishes it this way.