### PR TITLE
Update the radio button error checking

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,8 +168,10 @@ function myFunction() {
 	var mfInputline = document.getElementById("userEntry").value;
 	var warnOTP = "Are you sure that you meant Ovid to PubMed? I see PubMed syntax in your entry.";
   	var warnPTO = "Are you sure that you meant PubMed to Ovid? I see Ovid syntax in your entry";
+	var warnNoChoice = "Please make a selection: Ovid to PubMed or PubMed to Ovid";
   	warnOTP = warnOTP.fontcolor("red");
   	warnPTO = warnPTO.fontcolor("red");
+	warnNoChoice = warnNoChoice.fontcolor("red");
 
 
     if (rb1.checked && rb2.checked == false){
@@ -182,10 +184,10 @@ function myFunction() {
     	transposeOTP(mfInputline);
     }
     else if (rb1.checked == false && rb2.checked){
-	if (mfInputline.search(/exp/i) >= 0 && mfInputline.search(/\/ /i) >= 0){
+	if (mfInputline.search(/exp/i) >= 0 && mfInputline.search(/\//i) >= 0){
           document.getElementById("output5").innerHTML = warnPTO;
         }
-        else if (mfInputline.search(/.\w\w./) >= 0){
+        else if (mfInputline.search(/[.]\w\w[.]/) >= 0){
           document.getElementById("output5").innerHTML = warnPTO;
         }
         else{
@@ -193,8 +195,8 @@ function myFunction() {
         }
       	transposePTO(mfInputline);
     }
-	else{
-	    document.getElementById("output3").innerHTML = "error";
+	else if (rb1.checked == false && rb2.checked == false){
+	    document.getElementById("output5").innerHTML = warnNoChoice;
 	}
 
 }


### PR DESCRIPTION
Transpose now throws an error message if neither radio button is selected. Also, fixed the regex searching for .xx. search strategy in a PubMed strategy - now recognises literal period rather than period as a regex operator.