### PR TITLE
Field Code updates

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -138,32 +138,32 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.xm.</td>
 		      <td>[mh]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>MeSH Heading, Unexploded</td>
 		      <td>.sh.</td>
 		      <td>[mh:noexp]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>MeSH Heading Word</td>
 		      <td>.hw.</td>
 		      <td>N/A</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>Yes - a warning is given.</td>
 	      </tr>
 	      <tr>
 		      <td>Name of Substance Word</td>
 		      <td>.nm.</td>
 		      <td>[nm] or [supplementary concept]</td>
 		      <td>&nbsp;</td>
-		      <td>[supplementary concept] is implemented - others coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Pharmacological Action</td>
-		      <td>&nbsp;</td>
+		      <td>n/a</td>
 		      <td>[pa] or [pharmacological action]</td>
 		      <td>Closest equivalent is Ovid is to search as if it were a MeSH term</td>
 		      <td>Yes</td>
@@ -173,42 +173,42 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ps.</td>
 		      <td>[supplementary concept]</td>
 		      <td>&nbsp;</td>
-		      <td>[supplementary concept] is implemented - others coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Protocol Supplementary Concept Word</td>
 		      <td>.px.</td>
 		      <td>&nbsp;</td>
 		      <td>This will work for a supplementary concept which is only one word long, but not for part of a phrase.</td>
-		      <td>&nbsp;</td>
+		      <td>Yes - a warning is given.</td>
 	      </tr>
 	      <tr>
 		      <td>Rare Disease Supplementary Concept</td>
 		      <td>.rs.</td>
 		      <td>[supplementary concept]</td>
 		      <td>&nbsp;</td>
-		      <td>[supplementary concept] is implemented - others coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Rare Disease Supplementary Concept Word</td>
 		      <td>.rx.</td>
 		      <td>&nbsp;</td>
 		      <td>This will work for a supplementary concept which is only one word long, but not for part of a phrase.</td>
-		      <td>&nbsp;</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Subheading, Exploded</td>
 		      <td>.xs.</td>
 		      <td>[sh] or [subheading]</td>
 		      <td>Ovid version will only accept 2-letter code</td>
-		      <td>[sh] and [subheading] are implemented - others coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Subheading, Floating</td>
 		      <td>.fs.</td>
 		      <td>[sh:noexp] or [subheading:noexp]</td>
 		      <td>&nbsp;</td>
-		      <td>Coming soon!</td>
+		      <td>.fs is implemented. [sh:noexp] coming soon.</td>
 	      </tr>
       </table>
 
@@ -244,7 +244,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.kw.</td>
 		      <td>[ot]</td>
 		      <td>&nbsp;</td>
-		      <td>.kw. is implemented - [ot] coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Keyword Heading Word</td>
@@ -329,7 +329,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ot.</td>
 		      <td>[tt]</td>
 		      <td>&nbsp;</td>
-		      <td>.ot. is implemented, [tt] coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
       </table>
 
@@ -351,7 +351,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.au.</td>
 		      <td>[au] or [author]</td>
 		      <td>Ovid requires format: last name, space, first initial, optional truncation, e.g. smith a$. Ovid field .ax. accepts a last name without a first initial.</td>
-		      <td>[au] and [author] are implemented - .au. coming soon!</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Author, Corporate</td>
@@ -376,7 +376,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 	      </tr>
 	      <tr>
 		      <td>Author, Last</td>
-		      <td>&nbsp;</td>
+		      <td>n/a</td>
 		      <td>[lastau] or [author - last]</td>
 		      <td>&nbsp;</td>
 		      <td>&nbsp;</td>
@@ -386,28 +386,28 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ax.</td>
 		      <td>&nbsp;</td>
 		      <td>[au] or [author] accepts a last name without a first initial.</td>
-		      <td>&nbsp;</td>
+		      <td>Yes</td>
 	      </tr>
 	      <tr>
 		      <td>Issue/Part</td>
 		      <td>.ip.</td>
 		      <td>[ip] or [issue]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ip is implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Journal</td>
 		      <td>.jn.</td>
 		      <td>[journal]</td>
 		      <td>Phrase indexed - must have correct version of journal name.</td>
-		      <td>Coming soon!</td>
+		      <td>.jn is implemented - [journal] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Page/Pagination</td>
 		      <td>.pg.</td>
 		      <td>[pg] or [pagination]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.pg is implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>PMID/Unique Identifier</td>
@@ -428,14 +428,14 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.vo.</td>
 		      <td>[vi]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.vo is implemented. [vi] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Year of Publication</td>
 		      <td>.yr.</td>
 		      <td>&nbsp;</td>
 		      <td>This can be searched as the first 4 digits if the [dp] field in PubMed.</td>
-		      <td>&nbsp;</td>
+		      <td>Yes</td>
 	      </tr>
       </table>
 
@@ -457,56 +457,56 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.cp.</td>
 		      <td>[pl]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.cp is implemented. [pl] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>ISSN Electronic</td>
 		      <td>.es.</td>
 		      <td>[ta] or [journal]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.es is implemented. [ta] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>ISSN Linking</td>
 		      <td>.il.</td>
 		      <td>[ta] or [journal]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.il is implemented. [ta] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>ISSN Print</td>
 		      <td>.is.</td>
 		      <td>[ta] or [journal]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.is is implemented. [ta] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Journal ISO/Title Abbreviation</td>
 		      <td>.io.</td>
 		      <td>[ta]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.io is implemented. [ta] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Journal Subset</td>
 		      <td>.sb.</td>
 		      <td>[sb]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.sb is implemented. [sb] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Journal Word</td>
 		      <td>.jw.</td>
-		      <td>N/A</td>
+		      <td>n/a</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>Yes - a warning is given.</td>
 	      </tr>
 	      <tr>
 		      <td>NLM Journal Code</td>
 		      <td>.jc.</td>
 		      <td>[jid]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.jc is implemented. [jid] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>NLM Journal Name</td>
@@ -518,9 +518,9 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 	      <tr>
 		      <td>NLM Journal Word</td>
 		      <td>.nw.</td>
-		      <td>N/A</td>
+		      <td>n/a</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>Yes - a warning is given.</td>
 	      </tr>
       </table>
 
@@ -549,7 +549,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ed.</td>
 		      <td>[dcom]</td>
 		      <td>Format: YYYYMMDD in both databases. In Ovid, truncate with *. In PubMed, truncation is assumed (no symbol needed).</td>
-		      <td>&nbsp;</td>
+		      <td>.ed is implemented. [dcom] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date, Contribution</td>
@@ -563,7 +563,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.dt.?</td>
 		      <td>[crdt]</td>
 		      <td>The Ovid field called Create Date appears to correspond to the value of Entrez Date in PubMed - have contacted Ovid for clarification.</td>
-		      <td>&nbsp;</td>
+		      <td>.dt is implemented. [crdt] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date, Ending</td>
@@ -577,35 +577,35 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ez.?</td>
 		      <td>[edat]</td>
 		      <td>The Ovid field called Entrez Date appears to correspond to the value of Create Date in PubMed - have contacted Ovid for clarification.</td>
-		      <td>&nbsp;</td>
+		      <td>.ez is implemented. [edat] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date, Mesh</td>
 		      <td>.da.</td>
 		      <td>[mhda]</td>
 		      <td>Format: YYYY/MM/DD HH:MM in both databases. In Ovid, use a space where there would be a slash, and truncate with *. In PubMed, use a slash, and truncation is assumed (no symbol needed).</td>
-		      <td>&nbsp;</td>
+		      <td>.da is implemented. [mhda] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date, Modification/Revision</td>
 		      <td>.rd.</td>
 		      <td>[lr]</td>
 		      <td>Format: YYYYMMDD in both databases. In Ovid, truncate with *. In PubMed, truncation is assumed (no symbol needed).</td>
-		      <td>&nbsp;</td>
+		      <td>.rd is implemented. [lr] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date of Publication</td>
 		      <td>.dp.</td>
 		      <td>[dp]</td>
 		      <td>Format: YYYY Mmm DD in both databases. In addition to regular date format, pubmed allows the following format: &ldquo;last X days&rdquo;[dp]; &ldquo;last X months&rdquo;[dp]; &ldquo;last X year&rdquo;[dp] and also records date exactly as published in some cases (e.g. winter 2007).</td>
-		      <td>&nbsp;</td>
+		      <td>.dp is implemented. [dp] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date of Publication, Electronic</td>
 		      <td>.ep.</td>
 		      <td>[dep]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ep is implemented. [dep] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Date, Update</td>
@@ -623,7 +623,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 	      </tr>
 	      <tr>
 		      <td>Filter</td>
-		      <td>.et.</td>
+		      <td>.sb.</td>
 		      <td>[sb] or [filter]</td>
 		      <td>This may sometimes correspond to .sb. in Ovid. Further investigation required before implementation.</td>
 		      <td>&nbsp;</td>
@@ -640,7 +640,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>exp <em>Publication Type</em>/</td>
 		      <td>[pt] or [ptyp] or [publication type]</td>
 		      <td>E.g. exp Review/</td>
-		      <td>Yes</td>
+		      <td>PubMed to Ovid is implemented. Ovid to PubMed coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Publication Type, Unexploded</td>
@@ -654,7 +654,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.st.</td>
 		      <td>[sb]</td>
 		      <td>.st. is one of the searches corresponding to [sb].</td>
-		      <td>&nbsp;</td>
+		      <td>.st is implemented. [sb] coming soon.</td>
 	      </tr>
       </table>
 
@@ -676,28 +676,28 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.id.</td>
 		      <td>[aid]</td>
 		      <td>In Ovid, replace any punctuation with spaces.</td>
-		      <td>&nbsp;</td>
+		      <td>.id is implemented. [aid] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Author Name ID</td>
 		      <td>.ai.</td>
 		      <td>[auid]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ai is implemented. [auid] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>DOI/Location ID/Publisher Item Identifier</td>
 		      <td>.do,di.</td>
 		      <td>[lid]</td>
 		      <td>In Ovid, replace any punctuation with spaces.</td>
-		      <td>&nbsp;</td>
+		      <td>.do and .di have been implmented. [lid] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Grant Information</td>
 		      <td>.gr,gc,gi,no,go.</td>
 		      <td>[gr] or [grant number]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.gr,gc,gi,no,go. is implemented. [gr] coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Object ID</td>
@@ -754,7 +754,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ci.</td>
 		      <td>[coi] or [cois]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ci implemneted. Others coming soon!</td>
 	      </tr>
 	      <tr>
 		      <td>Copyright Index</td>
@@ -789,7 +789,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ir.</td>
 		      <td>[ir] or [investigator]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ir is implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Investigator Affiliation</td>
@@ -838,7 +838,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.pb.</td>
 		      <td>[pubn]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.pb is implemented. [pubn] coming soon.</td>
 	      </tr>
 	      <tr>
 	      <tr>
@@ -881,7 +881,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.si.</td>
 		      <td>[si] or [secondary source id]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.si implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Secondary Source Link</td>
@@ -1001,7 +1001,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ee.</td>
 		      <td>[ed] or [editor]</td>
 		      <td>No index provided in Ovid.</td>
-		      <td>&nbsp;</td>
+		      <td>.ee is implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Editor Full Name</td>
@@ -1029,7 +1029,7 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 		      <td>.ib.</td>
 		      <td>[is] or [isbn]</td>
 		      <td>&nbsp;</td>
-		      <td>&nbsp;</td>
+		      <td>.ib is implemented. Others coming soon.</td>
 	      </tr>
 	      <tr>
 		      <td>Media Type</td>

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@ function transposeOTP(inputline){
 					for (k = notLengthCounter; k >= 0; k--){
 
                     // is it a MeSH term?
-                    if (notArray[k].search(/\//) >= 0|notArray[k].search(/\.fs/) >= 0|notArray[k].search(/\.xs/) >= 0|notArray[k].search(/\.sh/) >= 0){
+                    if (notArray[k].search(/\//) >= 0|notArray[k].search(/\.fs/) >= 0|notArray[k].search(/\.xs/) >= 0){
 						outputReceiver = formatMesh(notArray[k]);
 						notArray[k] = outputReceiver[0];
 						warningArray[warningIndex] = outputReceiver[1];
@@ -387,11 +387,6 @@ function formatMesh (fmString) {
 
 	// publication types
 	var pubType = ["addresses", "autobiography", "bibliography", "biography", "case reports", "classical article", "clinical conference", "clinical study", "clinical trial", "clinical trial, phase i", "clinical trial, phase ii", "clinical trial, phase iii", "clinical trial, phase iv", "collected works", "comparative study", "congresses", "consensus development conference", "consensus development conference, nih", "controlled clinical trial", "dataset", "dictionary", "directory", "duplicate publication", "editorial", "english abstract", "evaluation studies", "festschrift", "government publications", "guideline", "historical article", "interactive tutorial", "interview", "introductory journal article", "journal article", "lectures", "legal cases", "legislation", "letter", "meta-analysis", "meta analysis", "multicenter study", "news", "newspaper article", "observational study", "overall", "patient education handout", "periodical index", "personal narratives", "portraits", "practice guideline", "pragmatic clinical trial", "publication components", "publication formats", "publication type category", "randomized controlled trial", "research support, american recovery and reinvestment act", "research support, n.i.h., extramural", "research support, n.i.h., intramural", "research support, non-u.s. gov't research support, u.s. gov't, non-p.h.s.", "research support, u.s. gov't, p.h.s.", "review", "scientific integrity review", "study characteristics", "support of research", "technical report", "twin study", "validation studies", "video-audio media", "webcasts"];
-
-    // .sh syntax
-    if (fmString.search(".sh") >= 0) {
-    	fmString = fmString.replace(".sh","/");
-    }
 
 	// floating or exploded subheadings
     if (fmString.search(/\.fs/i) >= 0|fmString.search(/\.xs/i) >= 0) {
@@ -683,51 +678,169 @@ function formatKeyword(kwString) {
 			kwWarningArray.push("The multipurpose (mp) field tag searches the following fields in ovid: abstract (ab), keyword heading word (kf), name of substance word (nm), original title (ot), protocol supplementary concept word (px), rare disease supplementary concept word (rx), subject heading word (hw), synonyms (sy), title (ti), unique identifier (ui). Many of these field codes cannot be searched in PubMed. Search has been translated as [tiab] OR [nm] OR [mh] OR [tt] OR [pmid]. For an inexact, but simpler translation, you may wish to search this term as a text word [tw] search instead.");
 			kwFieldArray.push("nm","mh","ot","ui");
 		}
+    // field codes are listed alphabetically after this point
 		else if (kwFieldArray[b].search(/ab/i) >= 0){ // abstract
 			kwFieldArray[b] = kwFieldArray[b].replace(/ab/i,"[tiab]");
 			kwWarningArray.push("PubMed does not support abstract-only searches. <b>.ab</b> has been replaced with <b>[tiab]</b>, which may retrieve more results.");
 		}
-		else if (kwFieldArray[b].search(/ot/i) >= 0){ // original title (transliterated title)
-			kwFieldArray[b] = kwFieldArray[b].replace(/ot/i,"[tt]");
-		}
-		else if (kwFieldArray[b].search(/kw/i) >= 0){ // keyword (other term)
-			kwFieldArray[b] = kwFieldArray[b].replace(/kw/i,"[ot]");
-		}
-    else if (kwFieldArray[b].search(/fa/i) >= 0){ // full author name
-      kwFieldArray[b] = kwFieldArray[b].replace(/fa/i,"[fau]");
-    }
-    else if (kwFieldArray[b].search(/pa/i) >= 0){ // first author name
-      kwFieldArray[b] = kwFieldArray[b].replace(/pa/i,"[1au]");
-    }
-    else if (kwFieldArray[b].search(/pn/i) >= 0){ // peronal name as subject
-      kwFieldArray[b] = kwFieldArray[b].replace(/pn/i,"[ps]");
-    }
-		else if (kwFieldArray[b].search(/lg/i) >= 0){ // language
-			kwFieldArray[b] = kwFieldArray[b].replace(/lg/i,"[la]");
-		}
-		else if (kwFieldArray[b].search(/jn/i) >= 0){ // journal title
-			kwFieldArray[b] = kwFieldArray[b].replace(/jn/i,"[jt]");
-		}
-    else if (kwFieldArray[b].search(/ja/i) >= 0){ // journal title abbreviated
-      kwFieldArray[b] = kwFieldArray[b].replace(/ja/i,"[ta]");
+    // .ai —> [auid]
+    else if (kwFieldArray[b].search(/ai/i) >= 0){ // Author Name ID
+      kwFieldArray[b] = kwFieldArray[b].replace(/ai/i,"[auid]");
     }
     else if (kwFieldArray[b].search(/af/i) >= 0){ // all fields
       kwFieldArray[b] = kwFieldArray[b].replace(/af/i,"[all]");
     }
-		else if (kwFieldArray[b].search(/hw/i) >= 0){ // heading word (no translation)
-			kwFieldArray[b] = kwFieldArray[b].replace(/hw/i,"[mh]");
-      kwWarningArray.push("PubMed does not support heading word (.hw) searches. The closest equivalent is mesh heading [mh], which may retrieve fewer results.");
-		}
-    else if (kwFieldArray[b].search(/kf/i) >= 0){ // keyword heading word (no translation)
-      kwFieldArray[b] = kwFieldArray[b].replace(/kf/i,"[ot]");
-      kwWarningArray.push("PubMed does not support keyword heading word (.hw) searches. The closest equivalent is other term [ot], which may retrieve fewer results.");
+    else if (kwFieldArray[b].search(/ax/i) >= 0){ // Author Last Name
+      kwFieldArray[b] = kwFieldArray[b].replace(/ax/i,"[au]");
     }
-    else if (kwFieldArray[b].search(/ui/i) >= 0){ // unique identifier
-      kwFieldArray[b] = kwFieldArray[b].replace(/ui/i,"[pmid]");
+    else if (kwFieldArray[b].search(/ci/i) >= 0){ // Conflict of Interest
+      kwFieldArray[b] = kwFieldArray[b].replace(/ci/i,"[coi]");
+    }
+    else if (kwFieldArray[b].search(/cp/i) >= 0){ // country of publication
+      kwFieldArray[b] = kwFieldArray[b].replace(/cp/i,"[pl]");
+    }
+    else if (kwFieldArray[b].search(/da/i) >= 0){ // Date, Mesh
+      kwFieldArray[b] = kwFieldArray[b].replace(/da/i,"[mhda]");
+    }
+    else if (kwFieldArray[b].search(/do/i) >= 0){ // DOI/Location ID/Publisher Item Identifier
+      kwFieldArray[b] = kwFieldArray[b].replace(/do/i,"[lid]");
+    }
+    else if (kwFieldArray[b].search(/di/i) >= 0){ // DOI/Location ID/Publisher Item Identifier
+      kwFieldArray[b] = kwFieldArray[b].replace(/di/i,"[lid]");
+    }
+    else if (kwFieldArray[b].search(/dt/i) >= 0){ // Date, Create
+      kwFieldArray[b] = kwFieldArray[b].replace(/dt/i,"[crdt]");
+    }
+    else if (kwFieldArray[b].search(/ed/i) >= 0){ // Date, Completion/Entry
+      kwFieldArray[b] = kwFieldArray[b].replace(/ed/i,"[dcom]");
+    }
+    else if (kwFieldArray[b].search(/ee/i) >= 0){ // Editor
+      kwFieldArray[b] = kwFieldArray[b].replace(/ee/i,"[ed]");
+    }
+    else if (kwFieldArray[b].search(/ep/i) >= 0){ // Date of Publication, Electronic
+      kwFieldArray[b] = kwFieldArray[b].replace(/ep/i,"[dep]");
+    }
+    else if (kwFieldArray[b].search(/es/i) >= 0){ // ISSN Electronic
+      kwFieldArray[b] = kwFieldArray[b].replace(/es/i,"[ta]");
+    }
+    else if (kwFieldArray[b].search(/ez/i) >= 0){ // Date, Entrez
+      kwFieldArray[b] = kwFieldArray[b].replace(/ez/i,"[edat]");
+    }
+    else if (kwFieldArray[b].search(/fa/i) >= 0){ // full author name
+      kwFieldArray[b] = kwFieldArray[b].replace(/fa/i,"[fau]");
+    }
+    else if (kwFieldArray[b].search(/gr|gc|gi|no|go/i) >= 0){ // Grant Information
+      kwFieldArray[b] = kwFieldArray[b].replace(/gr|gc|gi|no|go/i,"[gr]");
+    }
+    else if (kwFieldArray[b].search(/hw/i) >= 0){ // heading word (no translation)
+      kwFieldArray[b] = kwFieldArray[b].replace(/hw/i,"[mh]");
+      kwWarningArray.push("PubMed does not support heading word (.hw) searches. The closest equivalent is mesh heading [mh], which may retrieve fewer results.");
+    }
+    else if (kwFieldArray[b].search(/ib/i) >= 0){ // ISBN
+      kwFieldArray[b] = kwFieldArray[b].replace(/ib/i,"[is]");
+    }
+    else if (kwFieldArray[b].search(/id/i) >= 0){ // Article Identifier
+      kwFieldArray[b] = kwFieldArray[b].replace(/id/i,"[aid]");
+    }
+    else if (kwFieldArray[b].search(/il/i) >= 0){ // ISSN Linking
+      kwFieldArray[b] = kwFieldArray[b].replace(/il/i,"[ta]");
     }
     else if (kwFieldArray[b].search(/in/i) >= 0){ // institution
       kwFieldArray[b] = kwFieldArray[b].replace(/in/i,"[ad]");
     }
+    else if (kwFieldArray[b].search(/io/i) >= 0){ // Journal ISO/Title Abbreviation
+      kwFieldArray[b] = kwFieldArray[b].replace(/io/i,"[ta]");
+    }
+    else if (kwFieldArray[b].search(/is/i) >= 0){ // ISSN Print
+      kwFieldArray[b] = kwFieldArray[b].replace(/is/i,"[ta]");
+    }
+    else if (kwFieldArray[b].search(/ja/i) >= 0){ // journal title abbreviated
+      kwFieldArray[b] = kwFieldArray[b].replace(/ja/i,"[ta]");
+    }
+    else if (kwFieldArray[b].search(/jc/i) >= 0){ // NLM Journal Code
+      kwFieldArray[b] = kwFieldArray[b].replace(/jc/i,"[jid]");
+    }
+    else if (kwFieldArray[b].search(/jn/i) >= 0){ // journal title
+      kwFieldArray[b] = kwFieldArray[b].replace(/jn/i,"[journal]");
+    }
+    // lancet.jw —> warning message that there is no equivalent. Change to [journal].
+    else if (kwFieldArray[b].search(/jw/i) >= 0){ // journal word
+      kwFieldArray[b] = kwFieldArray[b].replace(/jw/i,"[journal]");
+      kwWarningArray.push("PubMed does not support journal word (.jw) searches. The closest equivalent is [journal], which may retrieve fewer results.");
+    }
+    else if (kwFieldArray[b].search(/kf/i) >= 0){ // keyword heading word (no translation)
+      kwFieldArray[b] = kwFieldArray[b].replace(/kf/i,"[ot]");
+      kwWarningArray.push("PubMed does not support keyword heading word (.kf) searches. The closest equivalent is other term [ot], which may retrieve fewer results.");
+    }
+    else if (kwFieldArray[b].search(/kw/i) >= 0){ // keyword (other term)
+      kwFieldArray[b] = kwFieldArray[b].replace(/kw/i,"[ot]");
+    }
+    else if (kwFieldArray[b].search(/lg/i) >= 0){ // language
+      kwFieldArray[b] = kwFieldArray[b].replace(/lg/i,"[la]");
+    }
+    else if (kwFieldArray[b].search(/nj/i) >= 0){ // NLM Journal Name
+      kwFieldArray[b] = kwFieldArray[b].replace(/nj/i,"[journal]");
+    }
+    else if (kwFieldArray[b].search(/nm/i) >= 0){ // name of substance word
+      kwFieldArray[b] = kwFieldArray[b].replace(/nm/i,"[supplementary concept]");
+    }
+    else if (kwFieldArray[b].search(/nw/i) >= 0){ // NLM Journal Word<
+      kwFieldArray[b] = kwFieldArray[b].replace(/nw/i,"[journal]");
+      kwWarningArray.push("PubMed does not support NLM journal word (.nw) searches. The closest equivalent is [journal], which may retrieve fewer results.");
+    }
+    // .oa —> warning that there is no equivalent. "This is one of the many fields searched by the [tiab] and [tw] searches in PubMed, but it cannot be searched separately.” Change to [tiab].
+    else if (kwFieldArray[b].search(/oa/i) >= 0){ // original title (transliterated title)
+      kwFieldArray[b] = kwFieldArray[b].replace(/oa/i,"[tiab]");
+      kwWarningArray.push("PubMed does not support Other Abstract (.oa) field tag searching. This is one of the many fields searched by the [tiab] and [tw] searches in PubMed, but it cannot be searched separately. Field has been changed to [tiab]");
+    }
+		else if (kwFieldArray[b].search(/ot/i) >= 0){ // original title (transliterated title)
+			kwFieldArray[b] = kwFieldArray[b].replace(/ot/i,"[tt]");
+		}
+    else if (kwFieldArray[b].search(/pa/i) >= 0){ // first author name
+      kwFieldArray[b] = kwFieldArray[b].replace(/pa/i,"[1au]");
+    }
+    else if (kwFieldArray[b].search(/pb/i) >= 0){ // Publisher
+      kwFieldArray[b] = kwFieldArray[b].replace(/pb/i,"[pubn]");
+    }
+    else if (kwFieldArray[b].search(/pn/i) >= 0){ // peronal name as subject
+      kwFieldArray[b] = kwFieldArray[b].replace(/pn/i,"[ps]");
+    }
+    else if (kwFieldArray[b].search(/ps/i) >= 0){ // Protocol Supplementary Concept
+      kwFieldArray[b] = kwFieldArray[b].replace(/ps/i,"[supplementary concept]");
+    }
+    else if (kwFieldArray[b].search(/px/i) >= 0){ // Protocol Supplementary Concept Word
+      kwFieldArray[b] = kwFieldArray[b].replace(/px/i,"[supplementary concept]");
+      kwWarningArray.push("PubMed only supports .px searches that are one word long (no phrases).");
+    }
+    else if (kwFieldArray[b].search(/rd/i) >= 0){ // Date, Modification/Revision
+      kwFieldArray[b] = kwFieldArray[b].replace(/rd/i,"[lr]");
+    }
+    else if (kwFieldArray[b].search(/rs/i) >= 0){ // Rare Disease Supplementary Concept
+      kwFieldArray[b] = kwFieldArray[b].replace(/rs/i,"[supplementary concept]");
+    }
+    else if (kwFieldArray[b].search(/rx/i) >= 0){ // Rare Disease Supplementary Concept Word
+      kwFieldArray[b] = kwFieldArray[b].replace(/rx/i,"[supplementary concept]");
+      kwWarningArray.push("PubMed only supports .rx searches that are one word long (no phrases).");
+    }
+    else if (kwFieldArray[b].search(/sh/i) >= 0){ // mesh heading unexploded
+      kwFieldArray[b] = kwFieldArray[b].replace(/sh/i,"[mesh:noexp]");
+    }
+    else if (kwFieldArray[b].search(/st/i) >= 0){ // Status
+      kwFieldArray[b] = kwFieldArray[b].replace(/st/i,"[sb]");
+    }
+    else if (kwFieldArray[b].search(/ui/i) >= 0){ // unique identifier
+      kwFieldArray[b] = kwFieldArray[b].replace(/ui/i,"[pmid]");
+    }
+    else if (kwFieldArray[b].search(/vo/i) >= 0){ // volume
+      kwFieldArray[b] = kwFieldArray[b].replace(/vo/i,"[vi]");
+    }
+    else if (kwFieldArray[b].search(/xm/i) >= 0){ // mesh heading exploded
+      kwFieldArray[b] = kwFieldArray[b].replace(/xm/i,"[mh]");
+    }
+    else if (kwFieldArray[b].search(/yr/i) >= 0){ // year
+      kwFieldArray[b] = kwFieldArray[b].replace(/yr/i,"[dp]");
+    }
+    // else replace .## with [##]
 		else {
       kwFieldArray[b] = "[" + kwFieldArray[b] + "]";
 		}


### PR DESCRIPTION
In this update the following OTP codes have been updated both in the
index page and documentation page:
.xm —> [mh]
.sh —> [mesh:noexp]
.nm —> [supplementary concept]
.ps —> [supplementary concept]
.px —> [supplementary concept] (only for one word long!)
.rs —> [supplementary concept]
.rx —> [supplementary concept] (only for one word long!)
.oa —> warning that there is no equivalent. "This is one of the many
fields searched by the [tiab] and [tw] searches in PubMed, but it
cannot be searched separately.” Change to [tiab].
.jn —> [journal] (currently translates to jt but this does not work!)
.vo —> [vi]
1999.yr —> 1999[dp]
denmark.cp —> "denmark"[pl]
0140-6736.es —> "0140-6736"[ta]
0140-6736.il —> "0140-6736"[ta]
0140-6736.is —> "0140-6736”[ta]
Am J Med.io —> "Am J Med”[ta]
lancet.jw —> warning message that there is no equivalent. Change to
[journal].
.jc —> [jid]
.nj —> [journal]
.nw —> warning message that there is no equivalent. Change to
[journal].
.st —> [sb]
.ed —> [dcom]
.dt —> [crdt]
.ez —> [edat]
.da —> [mhda]
.rd —> [lr]
.dp —> [dp]
.ep —> [dep]
.id —> [aid]
.ai —> [auid]
.do —> [lid]
.di —> [lid]
.ci —> [coi]
.pb —> [pubn]
.ee —> [ed]
.ib —> [is]
.ax —> [au]